### PR TITLE
add grunt-mkdocs-jwplayer to project for building locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 site/
 developer-guide
 node_modules
+npm-debug.log
+.self-update-info

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,34 @@
+module.exports = function (grunt) {
+
+  'use strict';
+
+  // configure grunt
+  grunt.initConfig({
+    'mkdocs-jwplayer': {
+      build: {
+        options: {
+          serve: false
+        }
+      },
+      serve: {
+        options: {
+          serve: true
+        }
+      }
+    }
+  });
+
+  // load grunt plugins
+  grunt.loadNpmTasks('grunt-mkdocs-jwplayer');
+
+  // default task runner
+  grunt.registerTask('default', [
+    'mkdocs-jwplayer:build'
+  ]);
+
+  // task runner for serving docs on localhost
+  grunt.registerTask('serve', [
+    'mkdocs-jwplayer:serve'
+  ]);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "jwplayer-docs-new",
+  "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-mkdocs-jwplayer": "github:jwplayer/grunt-mkdocs-jwplayer"
+  }
+}


### PR DESCRIPTION
Once this is merged, follow these steps when working locally:

```
$ npm install
```

And avoid using `mkdocs` commands. Instead, use the following:

```
$ grunt
$ grunt serve
```

This provides you a more reliable and up-to-date version of our MkDocs theme, thanks to our new Grunt plugin that self-updates your workspace.
