### PR TITLE
Fix/request timeout typo

### DIFF
--- a/docs/customization/configuration-reference.md
+++ b/docs/customization/configuration-reference.md
@@ -592,9 +592,8 @@ This options block configures the video advertising capabilities of JW Player. I
 |**advertising.forceNonLinearFullSlot**|Boolean|For forcing nonlinear ads to be fullsot ads rather than overlays|IMA|-|
 |**advertising.setLocale**|String|Valid two-letter language code for localization of skip-button language|IMA|-|
 |**advertising.creativeTimeout**|String|In milliseconds, the maximum amount of time between the VAST XML being returned and the adstart event before timing out|VAST|15000|
-|**advertising.requestTimeout**|String|In milliseconds, the maximum amount of time between the ad request and a returned VAST file before timing out|VAST|5000|
+|**advertising.requestTimeout**|String|In milliseconds, the maximum amount of time between the ad request and a returned VAST file before timing out|VAST, IMA|5000 (VAST), 10000 (IMA)|
 |**advertising.loadVideoTimeout**|String|In milliseconds, the maximum amount of time between the VAST XML being returned and the adstart event before timing out|IMA|15000|
-|**advertising.adsRequestTimeout**|String|In milliseconds, the maximum amount of time between the ad request and a returned VAST file before timing out|IMA|10000|
 |**advertising.maxRedirects**|String|The maximum number of redirects the player should follow before timing out|IMA|4|
 |**advertising.conditionaladoptout**|Boolean|(VPAID-only) Used to tell the player to not play ads with the **conditionalAd** attribute inside of the VAST response|VAST|false|
 |**advertising.podmessage**|String|Text that displays during playback of an ad pod. Use `__AD_POD_CURRENT__` to denote the currently playing item in the pod and `__AD_POD_LENGTH__` for the total number of ads in the pod.|VAST|"Ad xx of yy."|


### PR DESCRIPTION
Oops. There's no such thing as `adsRequestTimeout`. `requestTImeout` is for both VAST and IMA.