### PR TITLE
Use JavaScript types and detailed descriptions

### DIFF
--- a/docs/api/errors-reference.md
+++ b/docs/api/errors-reference.md
@@ -18,16 +18,16 @@ JW Player 8.4 introduces a new and improved error system in the player.  We have
 ### Properties
 |Name|Type|Attributes|Description|
 |---|---|---|---|
-|message|string| |The error message.|
-|code|ErrorCode|optional|The error code.|
-|sourceError|Error|optional|The lower level error, caught by the player, which resulted in this error.|
+|message|string| |The error message displayed to the user.|
+|code|Number|optional|The error code used to describe the error. Error code descriptions are listed on this page.|
+|sourceError|Error or Event|optional|The lower level error or event, caught by the player, which resulted in this error.|
 
 ### Example
 ```javascript
 {
   "code": 104153,
   "message": "Sorry, the video player failed to load.",
-  "sourceError": null,
+  "sourceError": { Error object or null },
   "type": "setupError"
 }
 ```


### PR DESCRIPTION
Use actual JavaScript types and detailed descriptions of error event properties. ErrorCode is not a JavaScript type. It is for internal JSDoc usage only.