### PR TITLE
[DOCS-238] Ad errors anchors

### DIFF
--- a/docs/advertising/ads_errors_reference.md
+++ b/docs/advertising/ads_errors_reference.md
@@ -1,5 +1,7 @@
 # Ads Errors Reference
 
+<sup>Last Updated: March 4, 2019</sup>
+
 JW Player is excited to help you monetize your content. With that being said, the complex nature of video advertising means that ad-related errors will happen from time to time. We hope that this list of error codes provides some insight into possible reasons that you are seeing these errors. We also have included possible solutions that may lead you to being able to resolve the issue.
 
 If you are still seeing ad-related issue after trying any applicable solutions, we highly recommend contacting your ad provider for further troubleshooting. This is because the player is primarily making the ad request using the URL you embed in the player and it is the responsibility of the ad provider to respond with a VAST-compatible response that the player can then display to your viewers. If they determine that they believe the issue is with the player, please open a case with [our Support Team](https://support.jwplayer.com/).

--- a/docs/api/errors-reference.md
+++ b/docs/api/errors-reference.md
@@ -1,5 +1,7 @@
 # JW Player Errors Reference
 
+<sup>Last Updated: March 4, 2019</sup>
+
 All errors and warnings relating to the player are returned in a player error object.
 
 ```javascript


### PR DESCRIPTION
## Player Developer Guide PR

### What does this Pull Request do?
- Adds HTML anchors for each of the Ad Error reference codes. This mimics what exists in the Error Reference article.
- Adds feedback form to both the Ad Errors Reference and Errors Reference pages.
- Adds the Last Updated date to both the Ad Errors Reference and Errors Reference pages.

### Why is this Pull Request needed?
- This allows internal engineers to link directly to the ad error codes from their products and features, in this case, JW Lens. This also allows individual errors to be referenced within documentation or to be shared with publishers.

### By what date must this update be published?
- ASAP

### Are there any points in the code sample(s) the reviewer needs to double check?
- N/A

### Are there any Pull Requests open in other repos which need to be merged with this?
- No.

### Is there anything else the reviewer should know or check?
- No.

#### Related Jira ticket(s):
- DOCS-238

Do not forget to tag @kcorneli201 and at least one other reviewer.
