### PR TITLE
[DOCS-17] vpb optional params

### DIFF
--- a/docs/customization/configuration-reference.md
+++ b/docs/customization/configuration-reference.md
@@ -754,7 +754,7 @@ jwplayer("myElement").setup({
 
 |Property|Type|Description|
 |---|---|---|
-|`content`| Object | OpenRTB content object. See: 3.2.16 Object: Content in the [OpenRTB 2.5](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) specification.
+|`content`| Object | OpenRTB content object. See: 3.2.16 Object: Content in the <a href="https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf" target="_blank">OpenRTB 2.5</a> specification.
 |`custom`| Object | Publisher-defined custom key-value pairs|
 |`price_floor`| Number | Price floor of this opportunity|
 |`token`| Object | Publisher-defined custom pass-through macros |


### PR DESCRIPTION
## Player Developer Guide PR

### What does this Pull Request do?
- Adds `advertising.bids.bidders[].optionalParams` object

### Why is this Pull Request needed?
- Explains properties that can be appended to an ad tag when SpotX is the ad partner

### By what date must this update be published?
- 3/7/19

### Are there any points in the code sample(s) the reviewer needs to double check?
- No.

### Are there any Pull Requests open in other repos which need to be merged with this?
- No.

### Is there anything else the reviewer should know or check?
- No.

#### Related Jira ticket(s):
- DOCS-17

Do not forget to tag @kcorneli201 and at least one other reviewer.
- Values confirmed by Chris Mulgannon.
