### PR TITLE
[DOCS-267] internationalization update

### DIFF
--- a/docs/customization/configuration-reference.md
+++ b/docs/customization/configuration-reference.md
@@ -1039,7 +1039,7 @@ jwplayer("myElement").setup({
 |<a name="intlplayback"></a>`playback`|String|Call-to-action text beneath the play button on the player idle screen.|Play|
 |`playbackRates`|String|Tooltip text for and `aria-label` HTML attribute of the playback rate controls menu|Playback Rates|
 |`player`|String|`aria-label` HTML attribute of the video player application|Video Player|
-|`playlist` <sup>< 8.8.0</sup>|String|Tooltip text for, overlay heading for, and `aria-label` HTML attribute of a playlist overlay<br/><br/><font color="red">**WARNING**</font>: Starting with JW Player 8.8.0, use the [related.heading](#intlrelatedheading) property to set this property.|Playlist|
+|`playlist` <sup>< 8.8.0</sup>|String|Tooltip text for, overlay heading for, and `aria-label` HTML attribute of a playlist overlay<br/><br/>**DEPRECATED**: Starting with JW Player 8.8.0, use the [related.heading](#intlrelatedheading) property to set this property.|Playlist|
 |`poweredBy`|String|Text displayed before the JW Player name and logo on a button in the Right-click menu.|Powered by|
 |`prev`|String|`aria-label` HTML attribute of the left arrow in overlays with multiple pages of videos|Previous|
 |`related`|Object|See: [related object](#intlrelated).|-|


### PR DESCRIPTION
## Player Developer Guide PR

### What does this Pull Request do?
- Adds note deprecating `intl.{lang}.playlist`

### Why is this Pull Request needed?
- Explains that `intl.{lang}.playlist` should not be used starting from JW Player 8.8.0

### By what date must this update be published?
- 3/7/19

### Are there any points in the code sample(s) the reviewer needs to double check?
- No.

### Are there any Pull Requests open in other repos which need to be merged with this?
- No.

### Is there anything else the reviewer should know or check?
- No.

#### Related Jira ticket(s):
- DOCS-267

Do not forget to tag @kcorneli201 and at least one other reviewer.
- Reviewed by Alicia
